### PR TITLE
Add link back to blog article

### DIFF
--- a/Monotonic XGBoost.ipynb
+++ b/Monotonic XGBoost.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sample is published as part of the corresponding blog article from the Toptal Engineering Blog, [Sound Logic and Monotonic AI Models](https://www.toptal.com/machine-learning/monotonic-ai-models)\n",
+    "\n",
+    "Visit [https://www.toptal.com/blog](https://www.toptal.com/blog) and subscribe to our newsletter to read great posts!\n",
+    "\n",
+    "* * *\n",
+    "\n",
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
Unfortunately, a GitHub bug has prevented me from previewing this to make sure the syntax is correct for a few days in a row now.  If you have a way of verifying, that would be helpful.  Thanks!